### PR TITLE
Add APIs to invoke scheduling related stored procedures

### DIFF
--- a/coreservice/coreservice-server/src/main/java/srinageswari/programmedhousehold/coreservice/controller/SchedulingController.java
+++ b/coreservice/coreservice-server/src/main/java/srinageswari/programmedhousehold/coreservice/controller/SchedulingController.java
@@ -1,7 +1,7 @@
 package srinageswari.programmedhousehold.coreservice.controller;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,20 +20,46 @@ public class SchedulingController {
   private final SchedulingService schedulingService;
 
   @PostMapping("/recipe/scheduleAll/{startDt}")
-  public ResponseEntity<APIResponseDTO<Void>> scheduleAll(@PathVariable Date startDt) {
+  public ResponseEntity<APIResponseDTO<Void>> scheduleAll(@PathVariable LocalDate startDt) {
     schedulingService.resetAllRecipeSchedules(startDt);
     return ResponseEntity.ok(new APIResponseDTO<>(LocalDateTime.now(), Constants.SUCCESS, null, 0));
   }
 
-  @PostMapping("/recipe/updateSubsequentSchedules")
-  public ResponseEntity<APIResponseDTO<Void>> updateSubsequentSchedules() {
-    schedulingService.updateSubsequentSchedules();
+  @PostMapping("/recipe/synchronizeRecipeCalendar")
+  public ResponseEntity<APIResponseDTO<Void>> synchronizeRecipeCalendar() {
+    schedulingService.synchronizeRecipeCalendar();
     return ResponseEntity.ok(new APIResponseDTO<>(LocalDateTime.now(), Constants.SUCCESS, null, 0));
   }
 
   @GetMapping("/recipes/today")
   public ResponseEntity<APIResponseDTO<List<RecipeResponseDTO>>> getTodaysRecipes() {
     final List<RecipeResponseDTO> response = schedulingService.getTodaysRecipes();
+    return ResponseEntity.ok(
+        new APIResponseDTO<>(LocalDateTime.now(), Constants.SUCCESS, response, response.size()));
+  }
+
+  @GetMapping("/recipes/date-range")
+  public ResponseEntity<APIResponseDTO<List<RecipeResponseDTO>>> getRecipesBetweenDates(
+      @RequestParam("startDate") LocalDate startDate, @RequestParam("endDate") LocalDate endDate) {
+    final List<RecipeResponseDTO> response =
+        schedulingService.findRecipesBetweenDates(startDate, endDate);
+    return ResponseEntity.ok(
+        new APIResponseDTO<>(LocalDateTime.now(), Constants.SUCCESS, response, response.size()));
+  }
+
+  @GetMapping("/recipes/current-week")
+  public ResponseEntity<APIResponseDTO<List<RecipeResponseDTO>>> getCurrentWeekRecipes() {
+    final List<RecipeResponseDTO> response = schedulingService.getCurrentWeekRecipes();
+    return ResponseEntity.ok(
+        new APIResponseDTO<>(LocalDateTime.now(), Constants.SUCCESS, response, response.size()));
+  }
+
+  @GetMapping("/recipes/selected-scheduleDates")
+  public ResponseEntity<APIResponseDTO<List<RecipeResponseDTO>>> getRecipesOnSelectedDates(
+      @RequestBody List<String> selectedScheduleDates) {
+    List<LocalDate> selectedDates = selectedScheduleDates.stream().map(LocalDate::parse).toList();
+    final List<RecipeResponseDTO> response =
+        schedulingService.getRecipesOnSelectedDates(selectedDates);
     return ResponseEntity.ok(
         new APIResponseDTO<>(LocalDateTime.now(), Constants.SUCCESS, response, response.size()));
   }

--- a/coreservice/coreservice-server/src/main/java/srinageswari/programmedhousehold/coreservice/repository/RecipeRepository.java
+++ b/coreservice/coreservice-server/src/main/java/srinageswari/programmedhousehold/coreservice/repository/RecipeRepository.java
@@ -1,10 +1,11 @@
 package srinageswari.programmedhousehold.coreservice.repository;
 
-import java.util.Date;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.query.Procedure;
 import org.springframework.stereotype.Repository;
 import srinageswari.programmedhousehold.coreservice.model.RecipeEntity;
 
@@ -14,15 +15,29 @@ import srinageswari.programmedhousehold.coreservice.model.RecipeEntity;
 @Repository
 public interface RecipeRepository
     extends JpaRepository<RecipeEntity, Long>, JpaSpecificationExecutor<RecipeEntity> {
-  @Query(value = "SELECT * FROM recipe r where r.category_id = ?1", nativeQuery = true)
+
+  @Query(
+      value = "SELECT * FROM recipe r where r.category_id = :categoryId ORDER BY scheduled_dt",
+      nativeQuery = true)
   List<RecipeEntity> findRecipesByCategoryId(Long categoryId);
 
-  @Query(value = "CALL RESET_ALL_RECIPE_SCHEDULES(:startDt)", nativeQuery = true)
-  void resetAllRecipeSchedules(Date startDt);
+  @Procedure(procedureName = "RESET_ALL_RECIPE_SCHEDULES")
+  void resetAllRecipeSchedules(LocalDate startDt);
 
   @Query(value = "SELECT * FROM recipe WHERE DATE(scheduled_dt) = CURDATE()", nativeQuery = true)
   List<RecipeEntity> queryTodaysRecipes();
 
-  @Query(value = "CALL UPDATE_SUBSEQUENT_SCHEDULES()", nativeQuery = true)
-  void updateSubsequentSchedules();
+  @Procedure(procedureName = "SYNC_RECIPE_CALENDAR")
+  void synchronizeRecipeCalendar();
+
+  @Query(
+      value =
+          "SELECT * FROM recipe r WHERE DATE(r.scheduled_dt) BETWEEN :startDate AND :endDate ORDER BY scheduled_dt",
+      nativeQuery = true)
+  List<RecipeEntity> findRecipesBetweenDates(LocalDate startDate, LocalDate endDate);
+
+  @Query(
+      value = "SELECT * FROM recipe r WHERE r.scheduled_dt IN :scheduleDates ORDER BY scheduled_dt",
+      nativeQuery = true)
+  List<RecipeEntity> getRecipesOnSelectedDates(List<LocalDate> scheduleDates);
 }

--- a/coreservice/coreservice-server/src/main/java/srinageswari/programmedhousehold/coreservice/service/recipe/SchedulingService.java
+++ b/coreservice/coreservice-server/src/main/java/srinageswari/programmedhousehold/coreservice/service/recipe/SchedulingService.java
@@ -1,6 +1,8 @@
 package srinageswari.programmedhousehold.coreservice.service.recipe;
 
-import java.util.Date;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,17 +17,37 @@ public class SchedulingService {
   private final RecipeRepository recipeRepository;
   private final RecipeServiceImpl recipeServiceImpl;
 
-  public void resetAllRecipeSchedules(Date startDt) {
+  public void resetAllRecipeSchedules(LocalDate startDt) {
     recipeRepository.resetAllRecipeSchedules(startDt);
   }
 
   // TODO: Implement cron job to run everyday to reschedule the previous day recipes
-  public void updateSubsequentSchedules() {
-    recipeRepository.updateSubsequentSchedules();
+  public void synchronizeRecipeCalendar() {
+    recipeRepository.synchronizeRecipeCalendar();
   }
 
   public List<RecipeResponseDTO> getTodaysRecipes() {
     return recipeRepository.queryTodaysRecipes().stream()
+        .map(recipeServiceImpl::getRecipeResponseDTO)
+        .toList();
+  }
+
+  public List<RecipeResponseDTO> getCurrentWeekRecipes() {
+    LocalDate startDt = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+    LocalDate endDt = LocalDate.now().with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+    return recipeRepository.findRecipesBetweenDates(startDt, endDt).stream()
+        .map(recipeServiceImpl::getRecipeResponseDTO)
+        .toList();
+  }
+
+  public List<RecipeResponseDTO> findRecipesBetweenDates(LocalDate startDt, LocalDate endDt) {
+    return recipeRepository.findRecipesBetweenDates(startDt, endDt).stream()
+        .map(recipeServiceImpl::getRecipeResponseDTO)
+        .toList();
+  }
+
+  public List<RecipeResponseDTO> getRecipesOnSelectedDates(List<LocalDate> selectedDates) {
+    return recipeRepository.getRecipesOnSelectedDates(selectedDates).stream()
         .map(recipeServiceImpl::getRecipeResponseDTO)
         .toList();
   }

--- a/coreservice/coreservice-server/src/main/resources/db/migration/V10.2024.02.06__handle_unscheduled_recipes_proc.sql
+++ b/coreservice/coreservice-server/src/main/resources/db/migration/V10.2024.02.06__handle_unscheduled_recipes_proc.sql
@@ -14,7 +14,7 @@ BEGIN
             SELECT DISTINCT c.day, c.meal
             FROM programmedhousehold.recipe r
                      JOIN programmedhousehold.category c ON r.category_id = c.category_id
-            WHERE c.day != 'NA'
+            WHERE c.day != 'NA' AND c.name != 'Leftover'
               AND r.is_active
               AND r.scheduled_dt IS NULL;
 
@@ -58,6 +58,7 @@ BEGIN
                     WHERE r.is_active
                       AND c.day = unscheduled_Day
                       AND c.meal = unscheduled_Meal
+                      AND c.name != 'Leftover'
                     GROUP BY 2, 3, 4, 5
                     ORDER BY 1, 2;
 
@@ -69,7 +70,8 @@ BEGIN
                     JOIN programmedhousehold.category c ON r.category_id = c.category_id
                 SET r.scheduled_dt = NULL
                 WHERE c.meal = unscheduled_Meal
-                  AND c.day = unscheduled_Day;
+                  AND c.day = unscheduled_Day
+                  AND c.name != 'Leftover';
 
                 -- Open inner cursor
                 OPEN reschedule_recipe_cur;
@@ -87,6 +89,7 @@ BEGIN
                              JOIN programmedhousehold.category c ON c.category_id = r.category_id
                     WHERE c.meal = reschedule_Meal
                       AND c.day = reschedule_Day
+                      AND c.name != 'Leftover'
                     LIMIT 1;
 
                     IF recent_scheduled_Dt IS NOT NULL THEN

--- a/coreservice/coreservice-server/src/main/resources/db/migration/V11.2024.02.06__synchronize_recipe_calendar_proc.sql
+++ b/coreservice/coreservice-server/src/main/resources/db/migration/V11.2024.02.06__synchronize_recipe_calendar_proc.sql
@@ -1,6 +1,6 @@
 DELIMITER //
 
-CREATE PROCEDURE UPDATE_SUBSEQUENT_SCHEDULES()
+CREATE PROCEDURE SYNC_RECIPE_CALENDAR()
 BEGIN
     DECLARE done INT DEFAULT FALSE;
     DECLARE category_name VARCHAR(100);
@@ -27,7 +27,7 @@ BEGIN
             LEAVE read_loop;
         END IF;
 
-        SELECT MAX(r.scheduled_dt) INTO recent_scheduled_Dt FROM recipe r JOIN programmedhousehold.category c ON c.category_id = r.category_id WHERE c.meal = schedule_Meal AND c.day = schedule_Day LIMIT 1;
+        SELECT MAX(r.scheduled_dt) INTO recent_scheduled_Dt FROM recipe r JOIN programmedhousehold.category c ON c.category_id = r.category_id WHERE c.meal = schedule_Meal AND c.day = schedule_Day AND c.name != 'Leftover' LIMIT 1;
         SET future_schedule_Dt = DATE_ADD(recent_scheduled_Dt,INTERVAL 7 DAY); -- Example calculation
         UPDATE recipe SET scheduled_dt = future_schedule_Dt WHERE id = recipe_id;
     END LOOP;

--- a/coreservice/coreservice-server/src/main/resources/db/migration/V9.2024.02.06__reset_all_recipe_schedules_proc.sql
+++ b/coreservice/coreservice-server/src/main/resources/db/migration/V9.2024.02.06__reset_all_recipe_schedules_proc.sql
@@ -28,7 +28,7 @@ BEGIN
                                       r.id
                                FROM recipe r
                                         join programmedhousehold.category c on r.category_id = c.category_id
-                               WHERE day != 'NA'
+                               WHERE day != 'NA' AND c.name != 'Leftover'
                                  AND r.is_active
                                GROUP BY 2, 3, 4, 5
                                ORDER BY 1, 2;
@@ -54,6 +54,7 @@ BEGIN
                      JOIN programmedhousehold.category c ON c.category_id = r.category_id
             WHERE c.meal = schedule_Meal
               AND c.day = schedule_Day
+              AND c.name != 'Leftover'
             LIMIT 1;
             IF recent_scheduled_Dt IS NOT NULL THEN
                 SET future_schedule_Dt = DATE_ADD(recent_scheduled_Dt, INTERVAL 7 DAY); -- Example calculation


### PR DESCRIPTION
1. Added API to invoke the scheduling procedures
2. Refactored the method name to SYNC_RECIPE_CALENDAR to keep it meaningful
3. Excluded LeftOver type recipe from procedures, as this needs to be handled manually